### PR TITLE
vcap.cc.events message is ARRAY, not HASH

### DIFF
--- a/lib/fluent/plugin/in_nats.rb
+++ b/lib/fluent/plugin/in_nats.rb
@@ -46,7 +46,7 @@ module Fluent
           @nats_conn.subscribe(@queue) do |msg, reply, sub|
             tag = "#{@tag}.#{sub}"
             msg_json = JSON.parse(msg)
-            time = msg_json["fluent_timestamp"] || Time.now.to_i 
+            time = Time.now_to_i
             Engine.emit(tag, time, msg_json)
           end
         }


### PR DESCRIPTION
Thank you for the nats plugin.
It is really nice.

Just one thing.
time = msg_json["fluent_timestamp"] || Time.now.to_i
When nats message is vcap.cc.events, the type of msg_json is Array, not Hash.
So it fails.

if the line is only "time = Time.now.to_i"
It works with including vcap.cc.events messages.

Thank you.
