### PR TITLE
Use Fluent::Engine for timing

### DIFF
--- a/lib/fluent/plugin/in_nats.rb
+++ b/lib/fluent/plugin/in_nats.rb
@@ -46,7 +46,7 @@ module Fluent
           @nats_conn.subscribe(@queue) do |msg, reply, sub|
             tag = "#{@tag}.#{sub}"
             msg_json = JSON.parse(msg)
-            time = msg_json["fluent_timestamp"] || Time.now.to_i 
+            time = msg_json["fluent_timestamp"] || Engine.now
             Engine.emit(tag, time, msg_json)
           end
         }

--- a/test/plugin/in_nats.rb
+++ b/test/plugin/in_nats.rb
@@ -71,6 +71,24 @@ class NATSInputTest < Test::Unit::TestCase
     kill_nats
   end
 
+  def test_emit_without_fluent_timestamp
+    d = create_driver
+
+    time = Time.now.to_i
+    Fluent::Engine.now = time
+
+    d.expect_emit "nats.fluent.test1", time, {"message"=>'nats'}
+
+    uri = "nats://#{d.instance.host}:#{d.instance.port}"
+    start_nats(uri)
+    d.run do
+      d.expected_emits.each do |tag, time, record|
+        send(uri, tag[5..-1], record)
+        sleep 0.5
+      end
+    end
+  end
+
 
   def setup
     Fluent::Test.setup


### PR DESCRIPTION
added test case that handles Hashes without the fluent_timestamp
