### PR TITLE
Implement a simple output plugin for NATS servers.

### DIFF
--- a/lib/fluent/plugin/out_nats.rb
+++ b/lib/fluent/plugin/out_nats.rb
@@ -1,0 +1,85 @@
+require "fluent/plugin/output"
+require "nats/client"
+
+module Fluent
+  module Plugin
+    class NATSOutput < Fluent::Plugin::Output
+      Fluent::Plugin.register_output('nats', self)
+
+      helpers :formatter, :thread, :inject
+
+      DEFAULT_FORMAT_TYPE = 'json'
+
+      desc "NATS server hostname"
+      config_param :host, :string, default: "localhost"
+      desc "Username for authorized connection"
+      config_param :user, :string, default: "nats"
+      desc "Password for authorized connection"
+      config_param :password, :string, default: "nats", secret: true
+      desc "NATS server port"
+      config_param :port, :integer, default: 4222
+      desc "Enable secure SSL/TLS connection"
+      config_param :ssl, :bool, default: false
+      desc "The max number of reconnect tries"
+      config_param :max_reconnect_attempts, :integer, default: 150
+      desc "The number of seconds to wait between reconnect tries"
+      config_param :reconnect_time_wait, :integer, default: 2
+
+      config_section :format do
+        config_set_default :@type, DEFAULT_FORMAT_TYPE
+        config_set_default :add_newline, false
+      end
+
+      def multi_workers_ready?
+        true
+      end
+
+      attr_accessor :formatter
+
+      def configure(conf)
+        super
+
+        @nats_config = {
+          uri: "nats://#{@host}:#{@port}",
+          ssl: @ssl,
+          user: @user,
+          pass: @password,
+          reconnect_time_wait: @reconnect_time_wait,
+          max_reconnect_attempts: @max_reconnect_attempts,
+        }
+        @formatter = formatter_create
+      end
+
+      def start
+        super
+        thread_create(:nats_output_main, &method(:run))
+      end
+
+      def shutdown
+        EM.next_tick { NATS.stop }
+        super
+      end
+
+      def run
+        NATS.on_error do |error_message|
+          log.error "Server Error: #{error_message}"
+          exit!
+        end
+        NATS.start(@nats_config) {
+          log.info "nats client is running for #{@nats_config[:uri]}"
+        }
+      end
+
+      def process(tag, es)
+        es = inject_values_to_event_stream(tag, es)
+        es.each {|time,record|
+          EM.next_tick { NATS.publish(tag, format(tag, time, record)) }
+        }
+      end
+
+      def format(tag, time, record)
+        @formatter.format(tag, time, record)
+      end
+    end
+  end
+end

--- a/test/plugin/test_out_nats.rb
+++ b/test/plugin/test_out_nats.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+require "fluent/test/driver/output"
+require "fluent/test/driver/input"
+require "fluent/plugin/out_nats"
+require "fluent/plugin/in_nats"
+require "fluent/time"
+
+class NATSOutputTest < Test::Unit::TestCase
+  include NATSTestHelper
+
+  CONFIG = %[
+    port 4222
+    host localhost
+    user nats
+    password nats
+  ]
+
+  CONFIG_INPUT = CONFIG + %[
+    queues test.>
+    tag nats
+  ]
+
+  def create_driver(conf)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::NATSOutput).configure(conf)
+  end
+
+  def create_input_driver(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::NATSInput).configure(conf)
+  end
+
+  def setup
+    Fluent::Test.setup
+    @time = Time.parse("2011-01-02 13:14:15 UTC")
+    Timecop.freeze(@time)
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  test "configuration test" do
+    d = create_driver(CONFIG)
+    assert_equal 4222, d.instance.port
+    assert_equal "localhost", d.instance.host
+    assert_equal "nats", d.instance.user
+    assert_equal "nats", d.instance.password
+  end
+
+  test "publish an event to NATS" do
+    d = create_driver(CONFIG)
+    input_driver = create_input_driver(CONFIG_INPUT)
+
+    time = Fluent::EventTime.now
+
+    uri = generate_uri(d)
+
+    run_server(uri) do
+      input_driver.run(expect_records: 1) do
+        d.run(default_tag: 'test.log') do
+          d.feed(time, {"test" => "test1"})
+        end
+      end
+    end
+    event = input_driver.events[0]
+    assert_equal(event[0], 'nats.test.log')
+    assert_equal(event[2], {"test" => "test1"})
+  end
+
+  def generate_uri(driver)
+    user = driver.instance.user
+    pass = driver.instance.password
+    host = driver.instance.host
+    port = driver.instance.port
+    if user && pass
+      "nats://#{user}:#{pass}@#{host}:#{port}"
+    else
+      "nats://#{host}:#{port}"
+    end
+  end
+end


### PR DESCRIPTION
This patch implements a simple output plugin for NATS servers.

### How it works

Basically this is a thin wrapper over the ruby client for NATS.
Here is how it work:

  1. Create a separate thread for running NATS client
  2. Events are passed to the NATS client by calling `NATS.publish`.
     (This is done inside `EM.next_tick`)
  3. Call NATS.stop on shutdown.

The beauty of this approach is that most of the tedious work (like
connection management and error handling) is managed by the NATS
client transparently. So we do not need to reinvent the wheel for
ourselves.